### PR TITLE
README.md : add webapi-vim link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ let g:mastodon_access_token = 'XXXXXXX'
 
 ## Requirements
 
-webapi-vim
+[webapi-vim](https://github.com/mattn/webapi-vim)
 
 ## License
 


### PR DESCRIPTION
Because it's quicker to follow a link than to make a search (-: