### PR TITLE
feat: Add support dynamic setting change

### DIFF
--- a/autoload/mastodon.vim
+++ b/autoload/mastodon.vim
@@ -13,9 +13,6 @@ let s:URLMATCH = s:URL_PROTOCOL.s:URL_DOMAIN.'\%(/'.s:URL_PATH.'\=\)\='
 let s:URLMATCH_HTTPS = s:URL_PROTOCOL_HTTPS.s:URL_DOMAIN.'\%(/'.s:URL_PATH.'\=\)\='
 let s:URLMATCH_NON_HTTPS = s:URL_PROTOCOL_NON_HTTPS.s:URL_DOMAIN.'\%(/'.s:URL_PATH.'\=\)\='
 
-let s:host = get(g:, 'mastodon_host')
-let s:access_token = get(g:, 'mastodon_access_token')
-
 function! s:to_text(str)
   let str = a:str
   let str = substitute(str, '<br\s*/\?>', "\n", 'g')
@@ -134,14 +131,17 @@ function! mastodon#complete(alead, cline, cpos)
 endfunction
 
 function! mastodon#call(...)
+  let host = get(g:, 'mastodon_host')
+  let access_token = get(g:, 'mastodon_access_token')
+
   let method = get(a:000, 0, '')
   let args = get(a:000, 1, '')
   if method == 'timeline'
-    let res = webapi#http#get(printf('https://%s/api/v1/timelines/home', s:host),
+    let res = webapi#http#get(printf('https://%s/api/v1/timelines/home', host),
 	\{
 	\},
 	\{
-    \ 'Authorization': 'Bearer ' . s:access_token,
+    \ 'Authorization': 'Bearer ' . access_token,
     \})
     if res.status != 200
       return res.message
@@ -150,24 +150,24 @@ function! mastodon#call(...)
     call s:show_timeline(items)
   elseif method == 'toot'
     let text = join(a:000[1:], " ")
-    let res = webapi#http#post(printf('https://%s/api/v1/statuses', s:host),
+    let res = webapi#http#post(printf('https://%s/api/v1/statuses', host),
 	\{
 	\  'status': text,
 	\},
 	\{
-    \ 'Authorization': 'Bearer ' . s:access_token,
+    \ 'Authorization': 'Bearer ' . access_token,
     \})
     if res.status != 200
       return res.message
     endif
   elseif method == 'toot-buffer'
     let text = join(a:000[1:], "\n")
-    let res = webapi#http#post(printf('https://%s/api/v1/statuses', s:host),
+    let res = webapi#http#post(printf('https://%s/api/v1/statuses', host),
 	\{
 	\  'status': text,
 	\},
 	\{
-    \ 'Authorization': 'Bearer ' . s:access_token,
+    \ 'Authorization': 'Bearer ' . access_token,
     \})
     if res.status != 200
       return res.message
@@ -176,8 +176,8 @@ function! mastodon#call(...)
     call s:show_timeline([])
     call webapi#http#stream(
 	\{
-	\  'url':    printf('https://%s/api/v1/streaming/public/local', s:host),
-	\  'header': {'Authorization': 'Bearer ' . s:access_token},
+	\  'url':    printf('https://%s/api/v1/streaming/public/local', host),
+	\  'header': {'Authorization': 'Bearer ' . access_token},
 	\  'out_cb': function('mastodon#add_item'),
 	\})
   endif

--- a/autoload/mastodon.vim
+++ b/autoload/mastodon.vim
@@ -133,6 +133,7 @@ endfunction
 function! mastodon#call(...)
   let host = get(g:, 'mastodon_host')
   let access_token = get(g:, 'mastodon_access_token')
+  let auth_header = {'Authorization': 'Bearer ' . access_token}
 
   let method = get(a:000, 0, '')
   let args = get(a:000, 1, '')
@@ -140,9 +141,7 @@ function! mastodon#call(...)
     let res = webapi#http#get(printf('https://%s/api/v1/timelines/home', host),
 	\{
 	\},
-	\{
-    \ 'Authorization': 'Bearer ' . access_token,
-    \})
+    \ auth_header)
     if res.status != 200
       return res.message
     endif
@@ -154,9 +153,7 @@ function! mastodon#call(...)
 	\{
 	\  'status': text,
 	\},
-	\{
-    \ 'Authorization': 'Bearer ' . access_token,
-    \})
+    \ auth_header)
     if res.status != 200
       return res.message
     endif
@@ -166,9 +163,7 @@ function! mastodon#call(...)
 	\{
 	\  'status': text,
 	\},
-	\{
-    \ 'Authorization': 'Bearer ' . access_token,
-    \})
+    \ auth_header)
     if res.status != 200
       return res.message
     endif
@@ -177,7 +172,7 @@ function! mastodon#call(...)
     call webapi#http#stream(
 	\{
 	\  'url':    printf('https://%s/api/v1/streaming/public/local', host),
-	\  'header': {'Authorization': 'Bearer ' . access_token},
+	\  'header': auth_header,
 	\  'out_cb': function('mastodon#add_item'),
 	\})
   endif

--- a/autoload/mastodon.vim
+++ b/autoload/mastodon.vim
@@ -138,10 +138,10 @@ function! mastodon#call(...)
   let method = get(a:000, 0, '')
   let args = get(a:000, 1, '')
   if method == 'timeline'
-    let res = webapi#http#get(printf('https://%s/api/v1/timelines/home', host),
-	\{
-	\},
-    \ auth_header)
+    let res = webapi#http#get(
+      \  printf('https://%s/api/v1/timelines/home', host),
+      \  {},
+      \  auth_header)
     if res.status != 200
       return res.message
     endif
@@ -149,32 +149,29 @@ function! mastodon#call(...)
     call s:show_timeline(items)
   elseif method == 'toot'
     let text = join(a:000[1:], " ")
-    let res = webapi#http#post(printf('https://%s/api/v1/statuses', host),
-	\{
-	\  'status': text,
-	\},
-    \ auth_header)
+    let res = webapi#http#post(
+      \  printf('https://%s/api/v1/statuses', host),
+      \  {'status': text},
+      \  auth_header)
     if res.status != 200
       return res.message
     endif
   elseif method == 'toot-buffer'
     let text = join(a:000[1:], "\n")
-    let res = webapi#http#post(printf('https://%s/api/v1/statuses', host),
-	\{
-	\  'status': text,
-	\},
-    \ auth_header)
+    let res = webapi#http#post(
+      \  printf('https://%s/api/v1/statuses', host),
+      \  {'status': text},
+      \  auth_header)
     if res.status != 200
       return res.message
     endif
   elseif method == 'stream'
     call s:show_timeline([])
-    call webapi#http#stream(
-	\{
-	\  'url':    printf('https://%s/api/v1/streaming/public/local', host),
-	\  'header': auth_header,
-	\  'out_cb': function('mastodon#add_item'),
-	\})
+    call webapi#http#stream({
+      \  'url':    printf('https://%s/api/v1/streaming/public/local', host),
+      \  'header': auth_header,
+      \  'out_cb': function('mastodon#add_item'),
+      \})
   endif
 endfunction
 


### PR DESCRIPTION
host and token using only in `mastodon#call`

* get host and token process move into `mastodon#call` (support dynamic settings chages)
* refactor auth header
* treat format

user customize example:

```vim
  function! s:mastodon_completion(A,L,P) abort
    let host_list = ['mstdn.jp', 'fedibird.com']
    return join(host_list,"\n")
  endfunction

  function! s:mastodon_change_hosttoken(host) abort
    let g:mastodon_host = a:host
    let g:mastodon_access_token = s:get_token(a:host)
  endfunction

  command! -nargs=1 -complete=custom,<SID>mastodon_completion MastodonHostChange :call <SID>mastodon_change_hosttoken(<f-args>)
``` 